### PR TITLE
Add external dashboard links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,3 +168,4 @@ plugins: [
 
 ## Assistant Memories
 - Always use context7. Let me know if you don't have access to it.
+- never mention yourself in git commits, merges, PRs, or anything else with git

--- a/src/components/AnalyticsClient.tsx
+++ b/src/components/AnalyticsClient.tsx
@@ -6,6 +6,7 @@ import { formatNumber, formatDuration, formatPercentage, formatChange, formatAxi
 import type { DashboardData, TimePeriod } from '../types'
 import { TIME_PERIOD_LABELS } from '../constants'
 import {SelectInput} from "@payloadcms/ui";
+import { ExternalLink } from './ExternalLink'
 
 export const AnalyticsClient: React.FC = () => {
   const [data, setData] = useState<DashboardData | null>(null)
@@ -16,12 +17,18 @@ export const AnalyticsClient: React.FC = () => {
   const [timePeriods, setTimePeriods] = useState<TimePeriod[]>(['day', '7d', '30d', '12mo'])
   const [defaultTimePeriod, setDefaultTimePeriod] = useState<TimePeriod>('7d')
   const [enableComparison, setEnableComparison] = useState<boolean>(true)
+  const [externalUrl, setExternalUrl] = useState<string | null>(null)
+  const [externalLinkText, setExternalLinkText] = useState<string>('View in Dashboard')
+  const [showExternalLink, setShowExternalLink] = useState<boolean>(true)
   
   useEffect(() => {
     if (typeof window !== 'undefined') {
       setTimePeriods((window as any).__analyticsTimePeriods || ['day', '7d', '30d', '12mo'])
       setDefaultTimePeriod((window as any).__analyticsDefaultTimePeriod || '7d')
       setEnableComparison((window as any).__analyticsEnableComparison !== false)
+      setExternalUrl((window as any).__analyticsExternalDashboardUrl || null)
+      setExternalLinkText((window as any).__analyticsExternalDashboardLinkText || 'View in Dashboard')
+      setShowExternalLink((window as any).__analyticsShowExternalLink !== false)
     }
   }, [])
   

--- a/src/components/AnalyticsView.tsx
+++ b/src/components/AnalyticsView.tsx
@@ -29,6 +29,9 @@ export const AnalyticsView: React.FC<AdminViewServerProps> = ({ initPageResult, 
   const defaultTimePeriod = (global as any).__analyticsDefaultTimePeriod
   const enableComparison = (global as any).__analyticsEnableComparison
   const dashboardPath = (global as any).__analyticsDashboardPath || '/analytics'
+  const externalDashboardUrl = (global as any).__analyticsExternalDashboardUrl
+  const externalDashboardLinkText = (global as any).__analyticsExternalDashboardLinkText
+  const showExternalLink = (global as any).__analyticsShowExternalLink
   
   // Get admin route from Payload config
   const adminRoute = '/admin' // Default admin route
@@ -53,13 +56,53 @@ export const AnalyticsView: React.FC<AdminViewServerProps> = ({ initPageResult, 
     <SetStepNav nav={navItems} />
     <div style={{ marginBottom: 'calc(var(--base) * 3)' }}>
       <Gutter>
-        <h1>Analytics Dashboard</h1>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+          <h1 style={{ margin: 0 }}>Analytics Dashboard</h1>
+          {showExternalLink && externalDashboardUrl && (
+            <a
+              href={externalDashboardUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '0.25rem',
+                color: 'var(--theme-text-light)',
+                textDecoration: 'none',
+                fontSize: '0.875rem',
+                transition: 'color 0.2s',
+              }}
+              onMouseEnter={(e) => e.currentTarget.style.color = 'var(--theme-text)'}
+              onMouseLeave={(e) => e.currentTarget.style.color = 'var(--theme-text-light)'}
+            >
+              {externalDashboardLinkText || 'View in Dashboard'}
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M5.75 10.25L10.25 5.75M10.25 5.75H6.5M10.25 5.75V9.5"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </a>
+          )}
+        </div>
         <script
           dangerouslySetInnerHTML={{
             __html: `
               window.__analyticsTimePeriods = ${JSON.stringify(timePeriods)};
               window.__analyticsDefaultTimePeriod = ${JSON.stringify(defaultTimePeriod)};
               window.__analyticsEnableComparison = ${JSON.stringify(enableComparison)};
+              window.__analyticsExternalDashboardUrl = ${JSON.stringify(externalDashboardUrl)};
+              window.__analyticsExternalDashboardLinkText = ${JSON.stringify(externalDashboardLinkText)};
+              window.__analyticsShowExternalLink = ${JSON.stringify(showExternalLink)};
             `,
           }}
         />

--- a/src/components/AnalyticsWidget.tsx
+++ b/src/components/AnalyticsWidget.tsx
@@ -3,10 +3,14 @@
 import React, { useEffect, useState } from 'react'
 import { formatNumber, formatPercentage, formatDuration } from '../lib/formatters'
 import type { DashboardData } from '../types'
+import { ExternalLink } from './ExternalLink'
 
 export const AnalyticsWidget: React.FC = () => {
   const [data, setData] = useState<DashboardData | null>(null)
   const [loading, setLoading] = useState(true)
+  const [externalUrl, setExternalUrl] = useState<string | null>(null)
+  const [externalLinkText, setExternalLinkText] = useState<string>('View in Dashboard')
+  const [showExternalLink, setShowExternalLink] = useState<boolean>(true)
 
   // Add styles
   useEffect(() => {
@@ -17,6 +21,26 @@ export const AnalyticsWidget: React.FC = () => {
         border: 1px solid var(--theme-elevation-200);
         border-radius: var(--style-radius-m);
         padding: calc(var(--base) * 1.5);
+        position: relative;
+      }
+      .analytics-external-link {
+        position: absolute;
+        bottom: calc(var(--base) * 1.5);
+        right: calc(var(--base) * 1.5);
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        color: var(--theme-text-light);
+        text-decoration: none;
+        font-size: 0.875rem;
+        transition: color 0.2s;
+      }
+      .analytics-external-link:hover {
+        color: var(--theme-text);
+      }
+      .analytics-external-link-icon {
+        width: 14px;
+        height: 14px;
       }
     `
     document.head.appendChild(style)
@@ -26,6 +50,13 @@ export const AnalyticsWidget: React.FC = () => {
   }, [])
 
   useEffect(() => {
+    // Get config from global
+    if (typeof window !== 'undefined') {
+      setExternalUrl((window as any).__analyticsExternalDashboardUrl || null)
+      setExternalLinkText((window as any).__analyticsExternalDashboardLinkText || 'View in Dashboard')
+      setShowExternalLink((window as any).__analyticsShowExternalLink !== false)
+    }
+    
     // Widget always shows today's data
     const apiRoute = (window as any).__payloadConfig?.routes?.api || '/api'
     fetch(`${apiRoute}/analytics/dashboard?period=day`, {
@@ -91,6 +122,12 @@ export const AnalyticsWidget: React.FC = () => {
           </div>
         </div>
       </div>
+      {showExternalLink && externalUrl && (
+        <ExternalLink 
+          href={externalUrl}
+          text={externalLinkText}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import React from 'react'
+
+interface ExternalLinkProps {
+  href: string
+  text: string
+  className?: string
+}
+
+export const ExternalLink: React.FC<ExternalLinkProps> = ({ href, text, className = '' }) => {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`analytics-external-link ${className}`}
+    >
+      {text}
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        className="analytics-external-link-icon"
+      >
+        <path
+          d="M5.75 10.25L10.25 5.75M10.25 5.75H6.5M10.25 5.75V9.5"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </a>
+  )
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,9 @@ export const analyticsPlugin = (pluginConfig: AnalyticsPluginConfig | LegacyAnal
     defaultTimePeriod = '7d',
     comparisonOptions = DEFAULT_COMPARISON_OPTIONS,
     enableComparison = true,
+    externalDashboardUrl,
+    externalDashboardLinkText,
+    showExternalLink = true,
   } = pluginConfig
 
   // Handle provider configuration - support both new and legacy patterns
@@ -94,6 +97,41 @@ export const analyticsPlugin = (pluginConfig: AnalyticsPluginConfig | LegacyAnal
     providerInstance = provider
   }
 
+  // Generate default external URL if not provided
+  let finalExternalUrl = externalDashboardUrl
+  if (!finalExternalUrl && typeof provider === 'string') {
+    switch (provider) {
+      case 'plausible':
+        if (providerConfig.siteId && providerConfig.apiHost) {
+          finalExternalUrl = `${providerConfig.apiHost}/${providerConfig.siteId}`
+        }
+        break
+      case 'umami':
+        if (providerConfig.siteId && providerConfig.apiHost) {
+          finalExternalUrl = `${providerConfig.apiHost}/websites/${providerConfig.siteId}`
+        }
+        break
+      case 'matomo':
+        if (providerConfig.siteId && providerConfig.apiHost) {
+          finalExternalUrl = `${providerConfig.apiHost}/index.php?module=CoreHome&action=index&idSite=${providerConfig.siteId}&period=day&date=today`
+        }
+        break
+      case 'posthog':
+        if (providerConfig.projectId && providerConfig.apiHost) {
+          finalExternalUrl = `${providerConfig.apiHost}/project/${providerConfig.projectId}/dashboard`
+        }
+        break
+      case 'google-analytics':
+        if (providerConfig.propertyId) {
+          finalExternalUrl = `https://analytics.google.com/analytics/web/#/report-home/a${providerConfig.propertyId}`
+        }
+        break
+    }
+  }
+
+  // Generate default link text if not provided
+  const finalLinkText = externalDashboardLinkText || `View in ${typeof provider === 'string' ? provider.charAt(0).toUpperCase() + provider.slice(1).replace(/-/g, ' ') : 'Dashboard'}`
+
   // Store provider and config in global for API routes and components
   ;(global as any).__analyticsProvider = providerInstance
   ;(global as any).__analyticsProviderName = typeof provider === 'string' ? provider : provider.name
@@ -103,6 +141,9 @@ export const analyticsPlugin = (pluginConfig: AnalyticsPluginConfig | LegacyAnal
   ;(global as any).__analyticsComparisonOptions = comparisonOptions
   ;(global as any).__analyticsEnableComparison = enableComparison
   ;(global as any).__analyticsDashboardPath = dashboardPath
+  ;(global as any).__analyticsExternalDashboardUrl = finalExternalUrl
+  ;(global as any).__analyticsExternalDashboardLinkText = finalLinkText
+  ;(global as any).__analyticsShowExternalLink = showExternalLink
   ;(global as any).__adminRoute = '/admin' // Default admin route
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,9 @@ interface BaseAnalyticsConfig {
   defaultTimePeriod?: TimePeriod
   comparisonOptions?: ComparisonOption[]
   enableComparison?: boolean
+  externalDashboardUrl?: string
+  externalDashboardLinkText?: string
+  showExternalLink?: boolean
 }
 
 // Provider-specific configurations using discriminated unions


### PR DESCRIPTION
## Summary
- Added external dashboard links to both the widget and analytics view
- Users can now navigate directly to their analytics provider's dashboard
- Configurable URL and link text with smart defaults for each provider

## Features
- New configuration options: `externalDashboardUrl`, `externalDashboardLinkText`, and `showExternalLink`
- Auto-generates provider-specific dashboard URLs when not provided
- External link appears in bottom-right of widget and top-right of analytics view
- Clean UI with arrow icon indicating external navigation
- Respects Payload's design system with proper hover states

## Test plan
- [ ] Test with each provider to ensure default URLs work correctly
- [ ] Test custom URL configuration
- [ ] Test custom link text
- [ ] Test disabling the feature with `showExternalLink: false`
- [ ] Verify styling matches Payload UI in both light and dark modes