### PR TITLE
Add date comparison selector

### DIFF
--- a/src/components/AnalyticsClient.tsx
+++ b/src/components/AnalyticsClient.tsx
@@ -3,9 +3,10 @@
 import React, { useEffect, useState } from 'react'
 import { XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Area, AreaChart } from 'recharts'
 import { formatNumber, formatDuration, formatPercentage, formatChange, formatAxisDate, formatTooltipDate } from '../lib/formatters'
-import type { DashboardData, TimePeriod } from '../types'
+import type { DashboardData, TimePeriod, ComparisonData } from '../types'
 import { TIME_PERIOD_LABELS } from '../constants'
 import {SelectInput} from "@payloadcms/ui";
+import { ComparisonSelector } from './ComparisonSelector'
 
 export const AnalyticsClient: React.FC = () => {
   const [data, setData] = useState<DashboardData | null>(null)
@@ -29,6 +30,7 @@ export const AnalyticsClient: React.FC = () => {
   const [showCustomDatePicker, setShowCustomDatePicker] = useState(false)
   const [customStartDate, setCustomStartDate] = useState('')
   const [customEndDate, setCustomEndDate] = useState(new Date().toISOString().split('T')[0])
+  const [comparison, setComparison] = useState<ComparisonData | null>(null)
 
   useEffect(() => {
     const fetchData = async () => {
@@ -39,6 +41,15 @@ export const AnalyticsClient: React.FC = () => {
         let url = `${apiRoute}/analytics/dashboard?period=${period}`
         if (period === 'custom' && customStartDate && customEndDate) {
           url = `${apiRoute}/analytics/dashboard?period=custom&start=${customStartDate}&end=${customEndDate}`
+        }
+        
+        // Add comparison parameters
+        if (comparison) {
+          if (comparison.period === 'custom' && comparison.customStartDate && comparison.customEndDate) {
+            url += `&comparison=custom&compareStart=${comparison.customStartDate}&compareEnd=${comparison.customEndDate}`
+          } else {
+            url += `&comparison=${comparison.period}`
+          }
         }
         const response = await fetch(url, {
           credentials: 'same-origin',
@@ -61,7 +72,7 @@ export const AnalyticsClient: React.FC = () => {
     if (period !== 'custom') {
       fetchData()
     }
-  }, [period])
+  }, [period, comparison])
 
   // Add custom styles for analytics
   useEffect(() => {
@@ -232,7 +243,8 @@ export const AnalyticsClient: React.FC = () => {
         gap: '1rem',
         marginBottom: '2rem'
       }}>
-        <div className="analytics-select-wrapper" style={{ width: '50%', minWidth: '300px' }}>
+        <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+          <div className="analytics-select-wrapper" style={{ flex: '1 1 300px', minWidth: '300px' }}>
           <SelectInput
             label="Time Period"
             name="analytics-period"
@@ -251,7 +263,21 @@ export const AnalyticsClient: React.FC = () => {
             isClearable={false}
             isSortable={false}
           />
+          </div>
+          
+          {enableComparison && (
+            <div className="analytics-select-wrapper" style={{ flex: '1 1 300px', minWidth: '300px' }}>
+              <ComparisonSelector
+                value={comparison}
+                onChange={setComparison}
+                currentPeriod={period}
+                currentStartDate={customStartDate}
+                currentEndDate={customEndDate}
+              />
+            </div>
+          )}
         </div>
+        
         <div style={{ 
           display: 'flex', 
           alignItems: 'center',
@@ -297,7 +323,17 @@ export const AnalyticsClient: React.FC = () => {
                 setLoading(true)
                 try {
                   const apiRoute = (window as any).__payloadConfig?.routes?.api || '/api'
-                  const url = `${apiRoute}/analytics/dashboard?period=custom&start=${customStartDate}&end=${customEndDate}`
+                  let url = `${apiRoute}/analytics/dashboard?period=custom&start=${customStartDate}&end=${customEndDate}`
+                  
+                  // Add comparison parameters
+                  if (comparison) {
+                    if (comparison.period === 'custom' && comparison.customStartDate && comparison.customEndDate) {
+                      url += `&comparison=custom&compareStart=${comparison.customStartDate}&compareEnd=${comparison.customEndDate}`
+                    } else {
+                      url += `&comparison=${comparison.period}`
+                    }
+                  }
+                  
                   const response = await fetch(url, {
                     credentials: 'same-origin',
                     headers: {
@@ -347,11 +383,14 @@ export const AnalyticsClient: React.FC = () => {
             color: 'var(--theme-text)',
             marginBottom: '0.5rem'
           }}>{formatNumber(stats.visitors.value)}</div>
-          {enableComparison && (
-            <div className={`analytics-stat-change ${stats.visitors.change && stats.visitors.change > 0 ? 'positive' : 'negative'}`} style={{
-              fontSize: '0.875rem'
+          {enableComparison && comparison && stats.visitors.change !== null && (
+            <div className={`analytics-stat-change ${stats.visitors.change > 0 ? 'positive' : 'negative'}`} style={{
+              fontSize: '0.875rem',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.25rem'
             }}>
-              {formatChange(stats.visitors.change).text} from previous period
+              {stats.visitors.change > 0 ? '↑' : '↓'} {Math.abs(stats.visitors.change).toFixed(1)}%
             </div>
           )}
         </div>
@@ -371,11 +410,14 @@ export const AnalyticsClient: React.FC = () => {
             color: 'var(--theme-text)',
             marginBottom: '0.5rem'
           }}>{formatNumber(stats.pageviews.value)}</div>
-          {enableComparison && (
-            <div className={`analytics-stat-change ${stats.pageviews.change && stats.pageviews.change > 0 ? 'positive' : 'negative'}`} style={{
-              fontSize: '0.875rem'
+          {enableComparison && comparison && stats.pageviews.change !== null && (
+            <div className={`analytics-stat-change ${stats.pageviews.change > 0 ? 'positive' : 'negative'}`} style={{
+              fontSize: '0.875rem',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.25rem'
             }}>
-              {formatChange(stats.pageviews.change).text} from previous period
+              {stats.pageviews.change > 0 ? '↑' : '↓'} {Math.abs(stats.pageviews.change).toFixed(1)}%
             </div>
           )}
         </div>
@@ -395,11 +437,14 @@ export const AnalyticsClient: React.FC = () => {
             color: 'var(--theme-text)',
             marginBottom: '0.5rem'
           }}>{formatPercentage(stats.bounce_rate.value)}</div>
-          {enableComparison && (
-            <div className={`analytics-stat-change ${stats.bounce_rate.change && stats.bounce_rate.change < 0 ? 'positive' : 'negative'}`} style={{
-              fontSize: '0.875rem'
+          {enableComparison && comparison && stats.bounce_rate.change !== null && (
+            <div className={`analytics-stat-change ${stats.bounce_rate.change < 0 ? 'positive' : 'negative'}`} style={{
+              fontSize: '0.875rem',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.25rem'
             }}>
-              {formatChange(stats.bounce_rate.change).text} from previous period
+              {stats.bounce_rate.change < 0 ? '↓' : '↑'} {Math.abs(stats.bounce_rate.change).toFixed(1)}%
             </div>
           )}
         </div>
@@ -419,11 +464,14 @@ export const AnalyticsClient: React.FC = () => {
             color: 'var(--theme-text)',
             marginBottom: '0.5rem'
           }}>{formatDuration(stats.visit_duration.value)}</div>
-          {enableComparison && (
-            <div className={`analytics-stat-change ${stats.visit_duration.change && stats.visit_duration.change > 0 ? 'positive' : 'negative'}`} style={{
-              fontSize: '0.875rem'
+          {enableComparison && comparison && stats.visit_duration.change !== null && (
+            <div className={`analytics-stat-change ${stats.visit_duration.change > 0 ? 'positive' : 'negative'}`} style={{
+              fontSize: '0.875rem',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.25rem'
             }}>
-              {formatChange(stats.visit_duration.change).text} from previous period
+              {stats.visit_duration.change > 0 ? '↑' : '↓'} {Math.abs(stats.visit_duration.change).toFixed(1)}%
             </div>
           )}
         </div>

--- a/src/components/ComparisonSelector.tsx
+++ b/src/components/ComparisonSelector.tsx
@@ -1,0 +1,154 @@
+'use client'
+
+import React, { useState, useEffect } from 'react'
+import { SelectInput } from '@payloadcms/ui'
+import type { ComparisonOption, ComparisonData } from '../types'
+
+interface ComparisonSelectorProps {
+  value: ComparisonData | null
+  onChange: (value: ComparisonData | null) => void
+  currentPeriod: string
+  currentStartDate?: string
+  currentEndDate?: string
+}
+
+const COMPARISON_OPTIONS = [
+  { label: 'No comparison', value: 'none' },
+  { label: 'Previous period', value: 'previousPeriod' },
+  { label: 'Same period last year', value: 'sameLastYear' },
+  { label: 'Custom date range', value: 'custom' },
+]
+
+export const ComparisonSelector: React.FC<ComparisonSelectorProps> = ({
+  value,
+  onChange,
+  currentPeriod,
+  currentStartDate,
+  currentEndDate,
+}) => {
+  const [showCustomDates, setShowCustomDates] = useState(false)
+  const [customStartDate, setCustomStartDate] = useState('')
+  const [customEndDate, setCustomEndDate] = useState('')
+
+  useEffect(() => {
+    if (value?.period === 'custom') {
+      setShowCustomDates(true)
+      setCustomStartDate(value.customStartDate || '')
+      setCustomEndDate(value.customEndDate || '')
+    } else {
+      setShowCustomDates(false)
+    }
+  }, [value])
+
+  const handleComparisonChange = (option: any) => {
+    if (!option || option.value === 'none') {
+      onChange(null)
+      setShowCustomDates(false)
+      return
+    }
+
+    const newValue = option.value as ComparisonOption
+    
+    if (newValue === 'custom') {
+      setShowCustomDates(true)
+      onChange({
+        period: 'custom',
+        customStartDate: customStartDate || new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+        customEndDate: customEndDate || new Date().toISOString().split('T')[0],
+      })
+    } else {
+      setShowCustomDates(false)
+      onChange({ period: newValue })
+    }
+  }
+
+  const handleCustomDateChange = (start: string, end: string) => {
+    if (start && end) {
+      onChange({
+        period: 'custom',
+        customStartDate: start,
+        customEndDate: end,
+      })
+    }
+  }
+
+  return (
+    <div className="analytics-comparison-wrapper">
+      <div style={{ marginBottom: showCustomDates ? '1rem' : 0 }}>
+        <SelectInput
+          label="Compare to"
+          name="analytics-comparison"
+          path="analytics-comparison"
+          value={value ? (value.period === 'custom' ? 'custom' : value.period) : 'none'}
+          onChange={handleComparisonChange}
+          options={COMPARISON_OPTIONS}
+        />
+      </div>
+      
+      {showCustomDates && (
+        <div style={{ 
+          display: 'flex', 
+          gap: '1rem',
+          alignItems: 'flex-end'
+        }}>
+          <div style={{ flex: 1 }}>
+            <label style={{ 
+              display: 'block', 
+              marginBottom: '0.5rem',
+              fontSize: '0.75rem',
+              fontWeight: '600',
+              color: 'var(--theme-text-light)'
+            }}>
+              Comparison start date
+            </label>
+            <input
+              type="date"
+              value={customStartDate}
+              onChange={(e) => {
+                setCustomStartDate(e.target.value)
+                handleCustomDateChange(e.target.value, customEndDate)
+              }}
+              style={{
+                width: '100%',
+                padding: '0.5rem',
+                border: '1px solid var(--theme-elevation-200)',
+                borderRadius: 'var(--style-radius-s)',
+                backgroundColor: 'var(--theme-elevation-50)',
+                color: 'var(--theme-text)',
+                fontSize: '0.875rem',
+              }}
+            />
+          </div>
+          <div style={{ flex: 1 }}>
+            <label style={{ 
+              display: 'block', 
+              marginBottom: '0.5rem',
+              fontSize: '0.75rem',
+              fontWeight: '600',
+              color: 'var(--theme-text-light)'
+            }}>
+              Comparison end date
+            </label>
+            <input
+              type="date"
+              value={customEndDate}
+              onChange={(e) => {
+                setCustomEndDate(e.target.value)
+                handleCustomDateChange(customStartDate, e.target.value)
+              }}
+              style={{
+                width: '100%',
+                padding: '0.5rem',
+                border: '1px solid var(--theme-elevation-200)',
+                borderRadius: 'var(--style-radius-s)',
+                backgroundColor: 'var(--theme-elevation-50)',
+                color: 'var(--theme-text)',
+                fontSize: '0.875rem',
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/providers/google-analytics.ts
+++ b/src/providers/google-analytics.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { AnalyticsProvider, DashboardData } from '../types'
+import { AnalyticsProvider, DashboardData, ComparisonData } from '../types'
 
 export interface GoogleAnalyticsConfig {
   propertyId?: string
@@ -143,7 +143,7 @@ export function createGoogleAnalyticsProvider(config: GoogleAnalyticsConfig = {}
 
   return {
     name: 'google-analytics',
-    async getDashboardData(period?: string): Promise<DashboardData | null> {
+    async getDashboardData(period: string = '7d', comparison?: ComparisonData): Promise<DashboardData | null> {
       try {
         const dateRanges = getGA4DateRange(period)
 

--- a/src/providers/matomo.ts
+++ b/src/providers/matomo.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import type { AnalyticsProvider, DashboardData } from '../types'
+import type { AnalyticsProvider, DashboardData, ComparisonData } from '../types'
 
 export interface MatomoConfig {
   apiToken?: string
@@ -130,7 +130,7 @@ export function createMatomoProvider(config: MatomoConfig): AnalyticsProvider {
   return {
     name: 'matomo',
     
-    async getDashboardData(period: string = '7d'): Promise<DashboardData | null> {
+    async getDashboardData(period: string = '7d', comparison?: ComparisonData): Promise<DashboardData | null> {
       if (!apiConfig.apiToken || !apiConfig.siteId) {
         console.warn('Matomo API token or site ID is not configured')
         return null

--- a/src/providers/posthog.ts
+++ b/src/providers/posthog.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { AnalyticsProvider, DashboardData } from '../types'
+import { AnalyticsProvider, DashboardData, ComparisonData } from '../types'
 
 export interface PostHogConfig {
   apiKey?: string
@@ -135,7 +135,7 @@ export function createPostHogProvider(config: PostHogConfig = {}): AnalyticsProv
 
   return {
     name: 'posthog',
-    async getDashboardData(period?: string): Promise<DashboardData | null> {
+    async getDashboardData(period: string = '7d', comparison?: ComparisonData): Promise<DashboardData | null> {
       try {
         const dateRange = getPostHogDateRange(period)
 

--- a/src/providers/umami.ts
+++ b/src/providers/umami.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import type { AnalyticsProvider, DashboardData } from '../types'
+import type { AnalyticsProvider, DashboardData, ComparisonData } from '../types'
 
 export interface UmamiConfig {
   apiKey?: string
@@ -136,7 +136,7 @@ export function createUmamiProvider(config: UmamiConfig): AnalyticsProvider {
   return {
     name: 'umami',
     
-    async getDashboardData(period: string = '7d'): Promise<DashboardData | null> {
+    async getDashboardData(period: string = '7d', comparison?: ComparisonData): Promise<DashboardData | null> {
       if (!apiConfig.apiKey || !apiConfig.siteId) {
         console.warn('Umami API key or site ID is not configured')
         return null

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import type { Config } from 'payload'
 
 export interface AnalyticsProvider {
   name: string
-  getDashboardData: (period?: string) => Promise<DashboardData | null>
+  getDashboardData: (period?: string, comparison?: ComparisonData) => Promise<DashboardData | null>
   trackEvent?: (eventName: string, props?: Record<string, any>) => void
 }
 
@@ -56,6 +56,12 @@ export type ComparisonOption =
   | 'previousPeriod' 
   | 'sameLastYear' 
   | 'custom'
+
+export interface ComparisonData {
+  period: ComparisonOption
+  customStartDate?: string
+  customEndDate?: string
+}
 
 export interface DashboardWidgetConfig {
   enabled?: boolean


### PR DESCRIPTION
## Summary
- Added a date comparison selector to the Analytics View
- Users can now compare current period data with previous periods
- Metric cards show percentage changes with visual indicators

## Features
- New ComparisonSelector component with three options:
  - Previous period
  - Same period last year  
  - Custom date range
- Updated metric cards to show clean percentage changes with up/down arrows
- Color-coded changes (green for positive, red for negative)
- For bounce rate, lower is better (inverted colors)
- Custom date range picker matches the existing date picker style

## Implementation
- Updated AnalyticsProvider interface to accept optional ComparisonData
- Modified endpoint to parse comparison parameters from query string
- Implemented comparison logic in Plausible provider (uses native comparison API)
- Updated all provider signatures for consistency
- Comparison selector only shows when enableComparison is true

## Test plan
- [ ] Test comparison selector with all three options
- [ ] Verify percentage changes display correctly
- [ ] Test custom date range comparison
- [ ] Ensure comparison works with different time periods
- [ ] Test with providers that don't support comparison (graceful fallback)
- [ ] Verify styling in light and dark modes