### PR TITLE
feat: add optional tabbed UI for collections and time series grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,22 +242,48 @@ analyticsPlugin({
     pages: {
       enabled: true,
       rootPath: '/',
+      tabbedUI: true, // Optional: add as tab (default) or group field
+      fields: ({ defaultFields }) => [...defaultFields], // Optional: customize fields
     },
     posts: {
       enabled: true,
       rootPath: '/blog',
+      tabbedUI: false, // Add as group field at end of collection
     },
   },
 })
 ```
 
-This adds an "Analytics" tab to each document in the specified collections, showing:
+**UI Options:**
+- **With `tabbedUI: true` (default)**: Analytics are added as a tab in your collection
+- **With `tabbedUI: false`**: Analytics are added as a group field at the end of your collection fields
+
+**Manual Field Usage:**
+
+You can also import and use the analytics field manually:
+
+```typescript
+import { CollectionAnalyticsField } from 'payload-analytics-plugin/fields'
+
+const Pages: CollectionConfig = {
+  slug: 'pages',
+  fields: [
+    // Your existing fields...
+    CollectionAnalyticsField('/', {
+      label: 'Page Analytics',
+      // Other field overrides
+    }),
+  ],
+}
+```
+
+This adds analytics showing:
 - Page-specific visitor count
 - Pageviews for that URL
 - Bounce rate
 - Average visit duration
 
-The analytics tab only appears for existing documents with a slug field. The plugin constructs the tracked URL as `{rootPath}/{slug}`.
+The analytics only appear for existing documents with a slug field. The plugin constructs the tracked URL as `{rootPath}/{slug}`.
 
 ## Environment Variables
 
@@ -296,7 +322,12 @@ The plugin will automatically use these environment variables if not explicitly 
 - **Visit Duration**: Average time spent on site
 
 ### Visualizations
-- **Time Series Chart**: Interactive visitor trends over time
+- **Time Series Chart**: Interactive visitor trends over time with grouping options:
+  - **Hour**: Available when viewing single day data
+  - **Day**: Daily aggregation (default)
+  - **Week**: Weekly aggregation
+  - **Month**: Monthly aggregation
+  - **Year**: Yearly aggregation
 - **Top Pages**: Most visited pages with metrics
 - **Traffic Sources**: Where your visitors come from
 - **Custom Events**: Goals and conversions tracking

--- a/fields/index.ts
+++ b/fields/index.ts
@@ -1,0 +1,1 @@
+export { CollectionAnalyticsField } from '../dist/fields/collectionAnalytics'

--- a/package.json
+++ b/package.json
@@ -7,8 +7,26 @@
   "files": [
     "dist",
     "components",
+    "fields",
     "README.md"
   ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./fields": {
+      "import": "./dist/fields/collectionAnalytics.js",
+      "types": "./dist/fields/collectionAnalytics.d.ts",
+      "default": "./dist/fields/collectionAnalytics.js"
+    },
+    "./types": {
+      "import": "./dist/types.js",
+      "types": "./dist/types.d.ts",
+      "default": "./dist/types.js"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",

--- a/src/endpoints/analytics.ts
+++ b/src/endpoints/analytics.ts
@@ -11,6 +11,7 @@ export const analyticsEndpoint = async (req: PayloadRequest): Promise<Response> 
   const period = url.searchParams.get('period') || '7d'
   const start = url.searchParams.get('start')
   const end = url.searchParams.get('end')
+  const grouping = url.searchParams.get('grouping') || 'day'
   
   // Get comparison parameters
   const comparisonType = url.searchParams.get('comparison')
@@ -33,7 +34,7 @@ export const analyticsEndpoint = async (req: PayloadRequest): Promise<Response> 
   }
   
   try {
-    const data = await provider.getDashboardData(effectivePeriod, comparison)
+    const data = await provider.getDashboardData(effectivePeriod, comparison, grouping as any)
     
     if (!data) {
       return Response.json({ error: 'Failed to fetch analytics data' }, { status: 500 })

--- a/src/fields/collectionAnalytics.ts
+++ b/src/fields/collectionAnalytics.ts
@@ -1,0 +1,53 @@
+import type { Field, GroupField, TextField } from 'payload'
+import type { CollectionAnalyticsConfig } from '../types'
+
+export interface CollectionAnalyticsFieldArgs {
+  config: CollectionAnalyticsConfig
+  overrides?: Partial<GroupField>
+}
+
+export const createCollectionAnalyticsFields = ({ config, overrides }: CollectionAnalyticsFieldArgs): Field[] => {
+  const analyticsField: GroupField = {
+    name: 'analytics',
+    type: 'group',
+    label: 'Analytics',
+    admin: {
+      condition: (_, siblingData) => {
+        // Only show for existing documents with a slug
+        return siblingData?.id && siblingData?.slug
+      },
+    },
+    fields: [
+      {
+        name: 'data',
+        type: 'ui',
+        admin: {
+          components: {
+            Field: {
+              clientProps: {
+                rootPath: config.rootPath,
+              },
+              path: 'payload-analytics-plugin/components/CollectionAnalyticsField',
+            },
+          },
+        },
+      },
+    ],
+    ...overrides,
+  }
+
+  // If fields customization is provided, use it
+  if (config.fields) {
+    return config.fields({ defaultFields: [analyticsField] })
+  }
+
+  return [analyticsField]
+}
+
+// Export a simpler function for manual use
+export const CollectionAnalyticsField = (rootPath: string, overrides?: Partial<GroupField>): GroupField => {
+  return createCollectionAnalyticsFields({
+    config: { enabled: true, rootPath },
+    overrides,
+  })[0] as GroupField
+}

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -32,9 +32,24 @@ export function formatChange(change: number | null): { text: string; isPositive:
   return { text, isPositive }
 }
 
-export function formatAxisDate(dateStr: string, period: string): string {
+export function formatAxisDate(dateStr: string, period: string, grouping?: string): string {
   const date = new Date(dateStr)
 
+  // Use grouping if provided, otherwise fall back to period-based formatting
+  if (grouping === 'hour') {
+    return date.toLocaleTimeString('en-US', { hour: 'numeric', hour12: true })
+  } else if (grouping === 'day') {
+    return date.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' })
+  } else if (grouping === 'week') {
+    // Show week starting date
+    return `Week of ${date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`
+  } else if (grouping === 'month') {
+    return date.toLocaleDateString('en-US', { month: 'short', year: '2-digit' })
+  } else if (grouping === 'year') {
+    return date.toLocaleDateString('en-US', { year: 'numeric' })
+  }
+  
+  // Fallback to period-based formatting
   if (period === 'day') {
     return date.toLocaleTimeString('en-US', { hour: 'numeric', hour12: true })
   } else if (period === '12mo') {
@@ -50,9 +65,24 @@ export function formatAxisDate(dateStr: string, period: string): string {
   }
 }
 
-export function formatTooltipDate(dateStr: string, period: string): string {
+export function formatTooltipDate(dateStr: string, period: string, grouping?: string): string {
   const date = new Date(dateStr)
 
+  // Use grouping if provided
+  if (grouping === 'hour') {
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) +
+      ' at ' + date.toLocaleTimeString('en-US', { hour: 'numeric', hour12: true })
+  } else if (grouping === 'week') {
+    const weekEnd = new Date(date)
+    weekEnd.setDate(date.getDate() + 6)
+    return `${date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} - ${weekEnd.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`
+  } else if (grouping === 'month') {
+    return date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+  } else if (grouping === 'year') {
+    return date.toLocaleDateString('en-US', { year: 'numeric' })
+  }
+  
+  // Fallback to period-based formatting
   if (period === 'day') {
     return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) +
       ' at ' + date.toLocaleTimeString('en-US', { hour: 'numeric', hour12: true })

--- a/src/providers/plausible.ts
+++ b/src/providers/plausible.ts
@@ -104,7 +104,7 @@ export function createPlausibleProvider(config: PlausibleConfig): AnalyticsProvi
   return {
     name: 'plausible',
     
-    async getDashboardData(period: string = '7d', comparison?: ComparisonData): Promise<DashboardData | null> {
+    async getDashboardData(period: string = '7d', comparison?: ComparisonData, grouping?: string): Promise<DashboardData | null> {
       if (!apiConfig.apiKey || !apiConfig.siteId) {
         console.warn('Plausible API key or site ID is not configured')
         return null
@@ -162,9 +162,17 @@ export function createPlausibleProvider(config: PlausibleConfig): AnalyticsProvi
           }
         }
 
+        // Map grouping to Plausible interval parameter
+        let interval = 'date' // default to day
+        if (grouping === 'hour') interval = 'hour'
+        else if (grouping === 'day') interval = 'date'
+        else if (grouping === 'week') interval = 'week'
+        else if (grouping === 'month') interval = 'month'
+        else if (grouping === 'year') interval = 'year'
+        
         const [statsResponse, timeseries, pages, sources, events, realtime] = await Promise.all([
           fetchPlausibleAPI(apiConfig, 'aggregate', apiParams, StatsSchema),
-          fetchPlausibleAPI(apiConfig, 'timeseries', { ...apiParams, metrics: 'visitors' }, z.object({ results: z.array(TimePeriodSchema) }))
+          fetchPlausibleAPI(apiConfig, 'timeseries', { ...apiParams, metrics: 'visitors', interval }, z.object({ results: z.array(TimePeriodSchema) }))
             .then(data => data?.results || []),
           fetchPlausibleAPI(apiConfig, 'breakdown', { ...apiParams, property: 'event:page', limit: '10', metrics: 'visitors,pageviews,bounce_rate,visit_duration' }, z.object({ results: z.array(PageSchema) }))
             .then(data => data?.results || []),

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import type { Config } from 'payload'
 
 export interface AnalyticsProvider {
   name: string
-  getDashboardData: (period?: string, comparison?: ComparisonData) => Promise<DashboardData | null>
+  getDashboardData: (period?: string, comparison?: ComparisonData, grouping?: TimeSeriesGrouping) => Promise<DashboardData | null>
   trackEvent?: (eventName: string, props?: Record<string, any>) => void
 }
 
@@ -57,6 +57,13 @@ export type ComparisonOption =
   | 'sameLastYear' 
   | 'custom'
 
+export type TimeSeriesGrouping = 
+  | 'hour'
+  | 'day'
+  | 'week'
+  | 'month'
+  | 'year'
+
 export interface ComparisonData {
   period: ComparisonOption
   customStartDate?: string
@@ -76,6 +83,8 @@ export interface AnalyticsViewConfig {
 export interface CollectionAnalyticsConfig {
   enabled: boolean
   rootPath: string
+  tabbedUI?: boolean
+  fields?: (args: { defaultFields: any[] }) => any[]
 }
 
 // Base configuration shared by all providers


### PR DESCRIPTION
## Summary
- Add optional tabbed UI for collection analytics (tabbedUI option)
- Export CollectionAnalyticsField for manual field usage
- Add time series grouping options with dynamic selector

## Changes

### Collection Analytics UI Options
- **tabbedUI**: Controls how analytics are added to collections
  - `true` (default): Adds as a tab (or creates tabs if none exist)
  - `false`: Adds as a group field at the end of collection
- **fields**: Function to customize the analytics fields
- Export `CollectionAnalyticsField` for manual usage in collections

### Time Series Grouping
- Added grouping selector to the chart section
- Available options: hour (day only), day, week, month, year
- Updated formatters to display dates appropriately for each grouping level
- Updated Plausible provider to map grouping to interval parameter

## Testing
- [ ] Collection analytics with tabbedUI: true
- [ ] Collection analytics with tabbedUI: false
- [ ] Manual CollectionAnalyticsField import and usage
- [ ] Time series grouping - all options
- [ ] Hour grouping only shows for day period
- [ ] Chart axis labels update correctly for each grouping